### PR TITLE
feat: デッキモデルの作成

### DIFF
--- a/src/models/Deck.ts
+++ b/src/models/Deck.ts
@@ -1,0 +1,68 @@
+import { Card } from "./Card";
+import { SUITS, RANKS } from "./constants";
+
+export class Deck {
+  gameType: string;
+  cards: Card[];
+
+  constructor(gamgeType: string) {
+    this.gameType = gamgeType;
+    this.cards = [];
+
+    // ゲームの種類によってデッキの作成方法を変える
+    switch (this.gameType) {
+      case "blackjack":
+        this.createBlackJackDeck();
+        break;
+
+      default:
+        throw new Error(`Invalid game type: ${this.gameType}`);
+    }
+  }
+
+  /**
+   * ブラックジャックのデッキを作成する(52枚)
+   * @returns {void}
+   */
+  private createBlackJackDeck(): void {
+    for (const suit of SUITS) {
+      for (const rank of RANKS) {
+        this.cards.push(new Card(suit, rank));
+      }
+    }
+  }
+
+  /**
+   * デッキをシャッフルする
+   * @returns {void}
+   */
+  shuffle(): void {
+    // Fisher-Yatesシャッフル(適当な数字を生成して、それを元にカードを入れ替える)
+    for (let i = this.cards.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [this.cards[i], this.cards[j]] = [this.cards[j], this.cards[i]];
+    }
+  }
+
+  /**
+   * デッキをリセットする（最初の状態に戻す）
+   * @returns {void}
+   */
+  resetDeck(): void {
+    this.cards = [];
+    switch (this.gameType) {
+      case "blackjack":
+        this.createBlackJackDeck();
+        break;
+    }
+    this.shuffle();
+  }
+
+  /**
+   * デッキからカードを1枚引く
+   * @returns {Card | null} 引いたカード（空なら `null`）
+   */
+  drawOne(): Card | null {
+    return this.cards.length > 0 ? this.cards.pop()! : null;
+  }
+}

--- a/src/models/__tests__/card/Card.test.ts
+++ b/src/models/__tests__/card/Card.test.ts
@@ -1,0 +1,10 @@
+import { describe, test, expect } from "vitest";
+import { Card } from "../../Card";
+
+describe("Cardクラスのテスト", () => {
+  test("スートとランクが正しく設定される", () => {
+    const card = new Card("S", "A");
+    expect(card.suit).toBe("S");
+    expect(card.rank).toBe("A");
+  });
+});

--- a/src/models/__tests__/card/getRankNumber.test.ts
+++ b/src/models/__tests__/card/getRankNumber.test.ts
@@ -1,13 +1,8 @@
 import { describe, test, expect } from "vitest";
-import { Card, Suit, Rank } from "../Card";
+import { Card } from "../../Card";
+import { SUITS, BLACKJACK_NUMERIC_RANKS } from "../../constants";
 
-describe("Card クラスのテスト", () => {
-  test("スートとランクが正しく設定される", () => {
-    const card = new Card("S", "A");
-    expect(card.suit).toBe("S");
-    expect(card.rank).toBe("A");
-  });
-
+describe("Cardクラスのテスト", () => {
   test("Aの数値は11", () => {
     const card = new Card("S", "A");
     expect(card.getRankNumber()).toBe("11");
@@ -20,10 +15,8 @@ describe("Card クラスのテスト", () => {
   });
 
   test("A, J, Q, K 以外の数値はその数値を返す", () => {
-    const suits: Suit[] = ["H", "D", "C", "S"];
-    const numberRanks: Rank[] = ["2", "3", "4", "5", "6", "7", "8", "9", "10"];
-    for (const rank of numberRanks) {
-      for (const suit of suits) {
+    for (const rank of BLACKJACK_NUMERIC_RANKS) {
+      for (const suit of SUITS) {
         const card = new Card(suit, rank);
         expect(card.getRankNumber()).toBe(rank);
       }

--- a/src/models/__tests__/deck/Deck.test.ts
+++ b/src/models/__tests__/deck/Deck.test.ts
@@ -1,0 +1,31 @@
+import { describe, test, expect } from "vitest";
+import { Deck } from "../../Deck";
+import { SUITS, RANKS } from "../../constants";
+
+describe("Deckクラスのテスト", () => {
+  test("デッキの枚数が52枚", () => {
+    const deck = new Deck("blackjack");
+    expect(deck.cards.length).toBe(52);
+  });
+
+  test("デッキにすべてのスートとランクが含まれている", () => {
+    const deck = new Deck("blackjack");
+    const cardSet = new Set(
+      deck.cards.map((card) => `${card.suit}-${card.rank}`)
+    );
+
+    // 期待される52枚のカードセットを作成
+    const expectedSet = new Set();
+    for (const suit of SUITS) {
+      for (const rank of RANKS) {
+        expectedSet.add(`${suit}-${rank}`);
+      }
+    }
+
+    expect(cardSet).toEqual(expectedSet);
+  });
+
+  test("BlackJack以外を指定", () => {
+    expect(() => new Deck("test")).toThrowError("Invalid game type: test");
+  });
+});

--- a/src/models/__tests__/deck/drawOne.test.ts
+++ b/src/models/__tests__/deck/drawOne.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from "vitest";
+import { Deck } from "../../Deck";
+
+describe("DeckクラスのdrawOneテスト", () => {
+  test("drawOne() を呼び出すとデッキの枚数が 1 減る", () => {
+    const deck = new Deck("blackjack");
+    const initialLength = deck.cards.length;
+
+    const drawnCard = deck.drawOne();
+
+    expect(drawnCard).not.toBeNull();
+    expect(deck.cards.length).toBe(initialLength - 1);
+  });
+
+  test("デッキが空のときに drawOne() を呼び出すと null を返す", () => {
+    const deck = new Deck("blackjack");
+
+    // 全部引く
+    for (let i = 0; i < 52; i++) {
+      deck.drawOne();
+    }
+
+    expect(deck.drawOne()).toBeNull();
+  });
+
+  test("引いたカードが元々デッキにあったカードである", () => {
+    const deck = new Deck("blackjack");
+    const originalSet = new Set(
+      deck.cards.map((card) => `${card.suit}-${card.rank}`)
+    );
+
+    const drawnCard = deck.drawOne();
+
+    expect(drawnCard).not.toBeNull();
+    if (drawnCard) {
+      expect(originalSet.has(`${drawnCard.suit}-${drawnCard.rank}`)).toBe(true);
+    }
+  });
+});

--- a/src/models/__tests__/deck/resetDeck.test.ts
+++ b/src/models/__tests__/deck/resetDeck.test.ts
@@ -1,0 +1,24 @@
+import { describe, test, expect } from "vitest";
+import { Deck } from "../../Deck";
+
+describe("DeckクラスのresetDeckテスト", () => {
+  test("リセット後もデッキの枚数が52枚", () => {
+    const deck = new Deck("blackjack");
+    deck.resetDeck();
+    expect(deck.cards.length).toBe(52);
+  });
+
+  test("リセット後もデッキ内容が変わらない", () => {
+    const deck = new Deck("blackjack");
+    const originalSet = new Set(
+      deck.cards.map((card) => `${card.suit}-${card.rank}`)
+    );
+
+    deck.resetDeck();
+
+    const shuffledSet = new Set(
+      deck.cards.map((card) => `${card.suit}-${card.rank}`)
+    );
+    expect(shuffledSet).toEqual(originalSet);
+  });
+});

--- a/src/models/__tests__/deck/shuffle.test.ts
+++ b/src/models/__tests__/deck/shuffle.test.ts
@@ -1,0 +1,24 @@
+import { describe, test, expect } from "vitest";
+import { Deck } from "../../Deck";
+
+describe("Deckクラスのshuffleテスト", () => {
+  test("シャッフル後もデッキの枚数が52枚", () => {
+    const deck = new Deck("blackjack");
+    deck.shuffle();
+    expect(deck.cards.length).toBe(52);
+  });
+
+  test("シャッフル後もデッキ内容が変わらない", () => {
+    const deck = new Deck("blackjack");
+    const originalSet = new Set(
+      deck.cards.map((card) => `${card.suit}-${card.rank}`)
+    );
+
+    deck.shuffle();
+
+    const shuffledSet = new Set(
+      deck.cards.map((card) => `${card.suit}-${card.rank}`)
+    );
+    expect(shuffledSet).toEqual(originalSet);
+  });
+});

--- a/src/models/constants.ts
+++ b/src/models/constants.ts
@@ -1,0 +1,31 @@
+import type { Suit, Rank } from "./Card";
+
+export const SUITS: Suit[] = ["H", "D", "C", "S"];
+
+export const RANKS: Rank[] = [
+  "A",
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "10",
+  "J",
+  "Q",
+  "K",
+];
+
+export const BLACKJACK_NUMERIC_RANKS: Rank[] = [
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "10",
+];


### PR DESCRIPTION
## 概要
デッキモデルを作成
- テストをメソッドごとに分割し保守性の向上
- カードの共通項目を定数化

Closes #2 